### PR TITLE
Add constructors with tls.Certificate, fix feedback tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package apns
 
 import (
 	"container/list"
+	"crypto/tls"
 	"io"
 	"log"
 	"time"
@@ -34,7 +35,7 @@ type Client struct {
 	id     uint32
 }
 
-func newClientWithConn(gw string, conn Conn) (Client, error) {
+func newClientWithConn(gw string, conn Conn) Client {
 	c := Client{
 		Conn:         &conn,
 		FailedNotifs: make(chan NotificationResult),
@@ -44,7 +45,13 @@ func newClientWithConn(gw string, conn Conn) (Client, error) {
 
 	go c.runLoop()
 
-	return c, nil
+	return c
+}
+
+func NewClientWithCert(gw string, cert tls.Certificate) Client {
+	conn := NewConnWithCert(gw, cert)
+
+	return newClientWithConn(gw, conn)
 }
 
 func NewClient(gw string, cert string, key string) (Client, error) {
@@ -53,7 +60,7 @@ func NewClient(gw string, cert string, key string) (Client, error) {
 		return Client{}, err
 	}
 
-	return newClientWithConn(gw, conn)
+	return newClientWithConn(gw, conn), nil
 }
 
 func NewClientWithFiles(gw string, certFile string, keyFile string) (Client, error) {
@@ -62,7 +69,7 @@ func NewClientWithFiles(gw string, certFile string, keyFile string) (Client, err
 		return Client{}, err
 	}
 
-	return newClientWithConn(gw, conn)
+	return newClientWithConn(gw, conn), nil
 }
 
 func (c *Client) Send(n Notification) error {

--- a/conn.go
+++ b/conn.go
@@ -23,14 +23,14 @@ type Conn struct {
 	connected bool
 }
 
-func newConnWithCert(gw string, cert tls.Certificate) (Conn, error) {
+func NewConnWithCert(gw string, cert tls.Certificate) Conn {
 	gatewayParts := strings.Split(gw, ":")
 	conf := tls.Config{
 		Certificates: []tls.Certificate{cert},
 		ServerName:   gatewayParts[0],
 	}
 
-	return Conn{gateway: gw, Conf: &conf}, nil
+	return Conn{gateway: gw, Conf: &conf}
 }
 
 // NewConnWithFiles creates a new Conn from certificate and key in the specified files
@@ -40,7 +40,7 @@ func NewConn(gw string, crt string, key string) (Conn, error) {
 		return Conn{}, err
 	}
 
-	return newConnWithCert(gw, cert)
+	return NewConnWithCert(gw, cert), nil
 }
 
 // NewConnWithFiles creates a new Conn from certificate and key in the specified files
@@ -50,7 +50,7 @@ func NewConnWithFiles(gw string, certFile string, keyFile string) (Conn, error) 
 		return Conn{}, err
 	}
 
-	return newConnWithCert(gw, cert)
+	return NewConnWithCert(gw, cert), nil
 }
 
 // Connect actually creates the TLS connection

--- a/feedback.go
+++ b/feedback.go
@@ -2,6 +2,7 @@ package apns
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/binary"
 	"encoding/hex"
 	"time"
@@ -34,6 +35,12 @@ func feedbackTupleFromBytes(b []byte) FeedbackTuple {
 		TokenLength: tokLen,
 		DeviceToken: hex.EncodeToString(tok),
 	}
+}
+
+func NewFeedbackWithCert(gw string, cert tls.Certificate) Feedback {
+	conn := NewConnWithCert(gw, cert)
+
+	return Feedback{Conn: &conn}
 }
 
 func NewFeedback(gw string, cert string, key string) (Feedback, error) {

--- a/feedback_test.go
+++ b/feedback_test.go
@@ -3,6 +3,7 @@ package apns_test
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"io/ioutil"
 	"os"
 	"time"
@@ -114,17 +115,26 @@ var _ = Describe("Feedback", func() {
 			f2 := bytes.NewBuffer([]byte{})
 			f3 := bytes.NewBuffer([]byte{})
 
+			// The final token strings
+			t1 := "00a18269661e9406aea59a5620b05c7c0e371574fa6f251951de8d7a5a292535"
+			t2 := "00a1a4b7294fcfbc5293f63d4298fcecd9c20a893befd45adceead5fc92d3319"
+			t3 := "00a1b7893d5e85eb8bb7bf0846b464d075248555118ae893b06e96cfb8d678e3"
+
+			bt1, _ := hex.DecodeString(t1)
+			bt2, _ := hex.DecodeString(t2)
+			bt3, _ := hex.DecodeString(t3)
+
 			binary.Write(f1, binary.BigEndian, uint32(1404358249))
-			binary.Write(f1, binary.BigEndian, uint16(32))
-			binary.Write(f1, binary.BigEndian, []byte("f111a111121112111111111411111111"))
+			binary.Write(f1, binary.BigEndian, uint16(len(bt1)))
+			binary.Write(f1, binary.BigEndian, bt1)
 
 			binary.Write(f2, binary.BigEndian, uint32(1404352249))
-			binary.Write(f2, binary.BigEndian, uint16(32))
-			binary.Write(f2, binary.BigEndian, []byte("f111a11112111bbbbb11111411111111"))
+			binary.Write(f2, binary.BigEndian, uint16(len(bt2)))
+			binary.Write(f2, binary.BigEndian, bt2)
 
 			binary.Write(f3, binary.BigEndian, uint32(1394352249))
-			binary.Write(f3, binary.BigEndian, uint16(32))
-			binary.Write(f3, binary.BigEndian, []byte("f111a11112111bbbbb11111499999999"))
+			binary.Write(f3, binary.BigEndian, uint16(len(bt3)))
+			binary.Write(f3, binary.BigEndian, bt3)
 
 			as := [][]serverAction{
 				[]serverAction{
@@ -143,18 +153,18 @@ var _ = Describe("Feedback", func() {
 
 					r1 := <-c
 					Expect(r1.Timestamp).To(Equal(time.Unix(1404358249, 0)))
-					Expect(r1.TokenLength).To(Equal(uint16(32)))
-					Expect(r1.DeviceToken).To(Equal("f111a111121112111111111411111111"))
+					Expect(r1.TokenLength).To(Equal(uint16(len(bt1))))
+					Expect(r1.DeviceToken).To(Equal(t1))
 
 					r2 := <-c
 					Expect(r2.Timestamp).To(Equal(time.Unix(1404352249, 0)))
-					Expect(r2.TokenLength).To(Equal(uint16(32)))
-					Expect(r2.DeviceToken).To(Equal("f111a11112111bbbbb11111411111111"))
+					Expect(r2.TokenLength).To(Equal(uint16(len(bt2))))
+					Expect(r2.DeviceToken).To(Equal(t2))
 
 					r3 := <-c
 					Expect(r3.Timestamp).To(Equal(time.Unix(1394352249, 0)))
-					Expect(r3.TokenLength).To(Equal(uint16(32)))
-					Expect(r3.DeviceToken).To(Equal("f111a11112111bbbbb11111499999999"))
+					Expect(r3.TokenLength).To(Equal(uint16(len(bt3))))
+					Expect(r3.DeviceToken).To(Equal(t3))
 
 					<-c
 					close(d)


### PR DESCRIPTION
Clears a bunch of `error` from signatures that never produce errors and adds new package functions to create components directly with the `tls.Certificate` object.
