### PR TITLE
Support Safari Push and Mobile Device Management

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -39,6 +39,8 @@ type NotificationResult struct {
 
 type Alert struct {
 	Body         string   `json:"body,omitempty"`
+	Title        string   `json:"title,omitempty"`
+	Action       string   `json:"action,omitempty"`
 	LocKey       string   `json:"loc-key,omitempty"`
 	LocArgs      []string `json:"loc-args,omitempty"`
 	ActionLocKey string   `json:"action-loc-key,omitempty"`
@@ -46,14 +48,17 @@ type Alert struct {
 }
 
 type APS struct {
-	Alert            Alert  `json:"alert,omitempty"`
-	Badge            *int   `json:"badge,omitempty"`
-	Sound            string `json:"sound,omitempty"`
-	ContentAvailable int    `json:"content-available,omitempty"`
+	Alert            Alert    `json:"alert,omitempty"`
+	Badge            *int     `json:"badge,omitempty"`
+	Sound            string   `json:"sound,omitempty"`
+	ContentAvailable int      `json:"content-available,omitempty"`
+	URLArgs          []string `json:"url-args,omitempty"`
 }
 
 type Payload struct {
-	APS          APS
+	APS APS
+	// MDM for mobile device management
+	MDM          string
 	customValues map[string]interface{}
 }
 
@@ -85,7 +90,11 @@ func (p *Payload) SetCustomValue(key string, value interface{}) error {
 }
 
 func (p *Payload) MarshalJSON() ([]byte, error) {
-	p.customValues["aps"] = p.APS
+	if len(p.MDM) != 0 {
+		p.customValues["mdm"] = p.MDM
+	} else {
+		p.customValues["aps"] = p.APS
+	}
 
 	return json.Marshal(p.customValues)
 }

--- a/notification_test.go
+++ b/notification_test.go
@@ -82,6 +82,26 @@ var _ = Describe("Notifications", func() {
 		})
 	})
 
+	Describe("Safari", func() {
+		Describe("#MarshalJSON", func() {
+			Context("with complete payload", func() {
+				It("should marshal APS", func() {
+					p := apns.NewPayload()
+
+					p.APS.Alert.Title = "Hello World!"
+					p.APS.Alert.Body = "This is a body"
+					p.APS.Alert.Action = "Launch"
+					p.APS.URLArgs = []string{"hello", "world"}
+
+					b, err := json.Marshal(p)
+
+					Expect(err).To(BeNil())
+					Expect(b).To(Equal([]byte(`{"aps":{"alert":{"body":"This is a body","title":"Hello World!","action":"Launch"},"url-args":["hello","world"]}}`)))
+				})
+			})
+		})
+	})
+
 	Describe("Payload", func() {
 		Describe("#MarshalJSON", func() {
 			Context("with only APS", func() {
@@ -108,6 +128,19 @@ var _ = Describe("Notifications", func() {
 
 					Expect(err).To(BeNil())
 					Expect(b).To(Equal([]byte(`{"aps":{"alert":{"body":"testing"}},"email":"come@me.bro"}`)))
+				})
+			})
+
+			Context("with only MDM", func() {
+				It("should marshal MDM", func() {
+					p := apns.NewPayload()
+
+					p.MDM = "00000000-1111-3333-4444-555555555555"
+
+					b, err := json.Marshal(p)
+
+					Expect(err).To(BeNil())
+					Expect(b).To(Equal([]byte(`{"mdm":"00000000-1111-3333-4444-555555555555"}`)))
 				})
 			})
 		})


### PR DESCRIPTION
Rounding out support different types push notifications:

* Title, Action and URLArgs are for Safari Push notifications.
* MDM is for Mobile Device Management.

This just allows these types of notifications through, it doesn't ensure that they are fully valid. I'm doing validations in advance.