### PR TITLE
Add category field to APS struct

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -50,6 +50,7 @@ type APS struct {
 	Badge            int    `json:"badge,omitempty"`
 	Sound            string `json:"sound,omitempty"`
 	ContentAvailable int    `json:"content-available,omitempty"`
+	Category         string `json:"category,omitempty"`
 }
 
 type Payload struct {


### PR DESCRIPTION
According to http://devstreaming.apple.com/videos/wwdc/2014/713xx1il4h4ur9c/713/713_whats_new_in_ios_notifications.pdf?dl=1 (slides 65+) iOS 8 adds support for new category field in aps object.
This PR adds the new field to corresponding struct.
