### PR TITLE
Support clearing out notifications (badge: 0)

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -47,7 +47,7 @@ type Alert struct {
 
 type APS struct {
 	Alert            Alert  `json:"alert,omitempty"`
-	Badge            int    `json:"badge,omitempty"`
+	Badge            *int   `json:"badge,omitempty"`
 	Sound            string `json:"sound,omitempty"`
 	ContentAvailable int    `json:"content-available,omitempty"`
 }

--- a/notification_test.go
+++ b/notification_test.go
@@ -113,6 +113,30 @@ var _ = Describe("Notifications", func() {
 		})
 	})
 
+	Describe("APS", func() {
+		Context("badge with a zero (clears notifications)", func() {
+			It("should contain zero", func() {
+				zero := 0
+				a := apns.APS{Badge: &zero}
+
+				j, err := json.Marshal(a)
+
+				Expect(err).To(BeNil())
+				Expect(j).To(Equal([]byte(`{"alert":{},"badge":0}`)))
+			})
+		})
+		Context("no badge specified (do nothing)", func() {
+			It("should omit the badge field", func() {
+				a := apns.APS{}
+
+				j, err := json.Marshal(a)
+
+				Expect(err).To(BeNil())
+				Expect(j).To(Equal([]byte(`{"alert":{}}`)))
+			})
+		})
+	})
+
 	Describe("Notification", func() {
 		Describe("#ToBinary", func() {
 			Context("invalid token format", func() {


### PR DESCRIPTION
I don't like this particular solution because it changes the API - and not in a nice way. :frowning: 

But this does provide specs for the issue. Badge: 0 and no badge have different behaviours on APNs. Right now it's not possible to clear out the badge and notifications list by sending 0 (Badge is omitempty and 0 is considered empty).
