### PR TITLE
Simple notification if .Body is the only Alert field non-empty

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -48,8 +48,12 @@ type Alert struct {
 	LaunchImage  string   `json:"launch-image,omitempty"`
 }
 
+func (a *Alert) isSimple() bool {
+	return len(a.Title) == 0 && len(a.Action) == 0 && len(a.LocKey) == 0 && len(a.LocArgs) == 0 && len(a.ActionLocKey) == 0 && len(a.LaunchImage) == 0
+}
+
 func (a *Alert) isZero() bool {
-	return len(a.Body) == 0 && len(a.LocKey) == 0 && len(a.LocArgs) == 0 && len(a.ActionLocKey) == 0 && len(a.LaunchImage) == 0
+	return a.isSimple() && len(a.Body) == 0
 }
 
 type APS struct {
@@ -65,7 +69,11 @@ func (aps APS) MarshalJSON() ([]byte, error) {
 	data := make(map[string]interface{})
 
 	if !aps.Alert.isZero() {
-		data["alert"] = aps.Alert
+		if aps.Alert.isSimple() {
+			data["alert"] = aps.Alert.Body
+		} else {
+			data["alert"] = aps.Alert
+		}
 	}
 	if aps.Badge != nil {
 		data["badge"] = aps.Badge

--- a/notification_test.go
+++ b/notification_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Notifications", func() {
 					b, err := json.Marshal(p)
 
 					Expect(err).To(BeNil())
-					Expect(b).To(Equal([]byte(`{"aps":{"alert":{"body":"testing"}}}`)))
+					Expect(b).To(Equal([]byte(`{"aps":{"alert":"testing"}}`)))
 				})
 			})
 
@@ -146,7 +146,7 @@ var _ = Describe("Notifications", func() {
 					b, err := json.Marshal(p)
 
 					Expect(err).To(BeNil())
-					Expect(b).To(Equal([]byte(`{"aps":{"alert":{"body":"testing"}},"email":"come@me.bro"}`)))
+					Expect(b).To(Equal([]byte(`{"aps":{"alert":"testing"},"email":"come@me.bro"}`)))
 				})
 			})
 


### PR DESCRIPTION
Following Apple's specs, this changes the marshaled JSON for `apns.Alert` to set the `alert` key to the text of `Alert.Body` if all other fields of the alert are empty. Also updated the `.isZero()` check to check the `.Title` and `.Action` properties of the alert.

From: https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html

> **Note**: If you want the device to display the message text as-is in an alert that has both the Close and View buttons, then specify a string as the direct value of alert. _Don’t_ specify a dictionary as the value of `alert` if the dictionary only has the `body` property.