### PR TITLE
Add support for email push notifications

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -63,6 +63,7 @@ type APS struct {
 	ContentAvailable int
 	URLArgs          []string
 	Category         string // requires iOS 8+
+	AccountId        string // for email push notifications
 }
 
 func (aps APS) MarshalJSON() ([]byte, error) {
@@ -89,6 +90,9 @@ func (aps APS) MarshalJSON() ([]byte, error) {
 	}
 	if aps.URLArgs != nil && len(aps.URLArgs) != 0 {
 		data["url-args"] = aps.URLArgs
+	}
+	if aps.AccountId != "" {
+		data["account-id"] = aps.AccountId
 	}
 
 	return json.Marshal(data)

--- a/notification_test.go
+++ b/notification_test.go
@@ -187,6 +187,16 @@ var _ = Describe("Notifications", func() {
 				Expect(j).To(Equal([]byte(`{}`)))
 			})
 		})
+		Context("email account id", func() {
+			It("should contain the account id", func() {
+				a := apns.APS{AccountId: "1234"}
+
+				j, err := json.Marshal(a)
+
+				Expect(err).To(BeNil())
+				Expect(j).To(Equal([]byte(`{"account-id":"1234"}`)))
+			})
+		})
 	})
 
 	Describe("Notification", func() {


### PR DESCRIPTION
This patch adds support for Email Push Notifications by introducing an `AccountId` field in the `APNS` structure.

This is used in my https://github.com/st3fan/dovecot-xaps-daemon project. (The master branch is in *Python* but I have recently rewritten this tool in *Go* and the version in the `go` branch depends on the https://github.com/timehop/apns project)