### PR TITLE
New `BadgeNumber` struct to handle badging - an alternative to using an *int

### DIFF
--- a/badge_number.go
+++ b/badge_number.go
@@ -1,0 +1,71 @@
+package apns
+
+import (
+	"errors"
+	"strconv"
+)
+
+// BadgeNumber is much a NullInt64 in
+// database/sql except instead of using
+// the nullable value for driver.Value
+// encoding and decoding, this is specifically
+// meant for JSON encoding and decoding
+type BadgeNumber struct {
+	Number int
+	Valid  bool
+}
+
+// NewBadgeNumber returns a valid BadgeNumber
+// with the value passed in
+func NewBadgeNumber(number int) BadgeNumber {
+	return BadgeNumber{
+		Number: number,
+		Valid:  true,
+	}
+}
+
+// Unset will reset the BadgeNumber to
+// both 0 and invalid
+func (b *BadgeNumber) Unset() {
+	b.Number = 0
+	b.Valid = false
+}
+
+// Set will set the BadgeNumber value to
+// the number passed in, assuming it's >= 0.
+// If so, the BadgeNumber will also be marked valid
+func (b *BadgeNumber) Set(number int) error {
+	if number < 0 {
+		return errors.New("Number must be >= 0")
+	}
+
+	b.Number = number
+	b.Valid = true
+	return nil
+}
+
+// MarshalJSON will marshall the numerical value of
+// BadgeNumber
+func (b BadgeNumber) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(b.Number)), nil
+}
+
+// UnmarshalJSON will take any non-nil value and
+// set BadgeNumber's numeric value to it. It assumes
+// that if the unmarshaller gets here, there is a
+// number to unmarshal and it's valid
+func (b *BadgeNumber) UnmarshalJSON(data []byte) error {
+	if val, err := strconv.ParseInt(string(data), 10, 32); err != nil {
+		return err
+	} else {
+		b.Number = int(val)
+
+		// Since the point of this type is to
+		// allow proper inclusion of 0 for int
+		// types while respecting omitempty,
+		// assume that set==true if there is
+		// a value to unmarshal
+		b.Valid = true
+		return nil
+	}
+}

--- a/badge_number_test.go
+++ b/badge_number_test.go
@@ -1,10 +1,11 @@
-package apns
+package apns_test
 
 import (
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/timehop/apns"
 )
 
 var _ = Describe("BadgeNumber", func() {

--- a/badge_number_test.go
+++ b/badge_number_test.go
@@ -1,0 +1,78 @@
+package apns
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BadgeNumber", func() {
+	Describe("Defaults", func() {
+		It("Should have the proper default values", func() {
+			b := BadgeNumber{}
+			Expect(b.Number).To(Equal(0))
+			Expect(b.Valid).To(BeFalse())
+		})
+	})
+
+	Describe("NewBadgeNumber", func() {
+		var b BadgeNumber
+
+		Context("with an argument", func() {
+			It("should have values set properly", func() {
+				b = NewBadgeNumber(5)
+				Expect(b.Valid).To(BeTrue())
+				Expect(b.Number).To(Equal(5))
+			})
+		})
+		Context("when unset", func() {
+			It("should reset its values", func() {
+				b.Unset()
+				Expect(b.Valid).To(BeFalse())
+				Expect(b.Number).To(Equal(0))
+			})
+		})
+	})
+
+	Describe("JSON handling", func() {
+		type BadgeNumbers struct {
+			A BadgeNumber `json:"a"`
+			B BadgeNumber `json:"b"`
+		}
+
+		Context("when marshalling", func() {
+			It("should not error", func() {
+				_, err := json.Marshal(BadgeNumbers{
+					A: NewBadgeNumber(10),
+				})
+				Expect(err).To(BeNil())
+			})
+			It("should create the proper values", func() {
+				bn := BadgeNumbers{
+					A: NewBadgeNumber(10),
+				}
+				b, _ := json.Marshal(bn)
+				expected := "{\"a\":10,\"b\":0}"
+				Expect(string(b)).To(Equal(expected))
+			})
+		})
+
+		Context("when unmarshalled", func() {
+			var bnumbers BadgeNumbers
+
+			It("should unmarshal without errors", func() {
+				err := json.Unmarshal([]byte("{\"a\":10,\"b\":0}"), &bnumbers)
+				Expect(err).To(BeNil())
+			})
+			It("should populate the struct properly", func() {
+				json.Unmarshal([]byte("{\"a\":10,\"b\":0}"), &bnumbers)
+				Expect(bnumbers.A.Valid).To(BeTrue())
+				Expect(bnumbers.B.Valid).To(BeTrue())
+
+				Expect(bnumbers.A.Number).To(Equal(10))
+				Expect(bnumbers.B.Number).To(Equal(0))
+			})
+		})
+	})
+})

--- a/example/example.go
+++ b/example/example.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"apns"
 	"fmt"
 	"log"
-
-	"apns"
 
 	"github.com/timehop/apns"
 )

--- a/example/example.go
+++ b/example/example.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"apns"
+
 	"github.com/timehop/apns"
 )
 
@@ -28,7 +30,7 @@ func main() {
 
 		p := apns.NewPayload()
 		p.APS.Alert.Body = body
-		p.APS.Badge = &badge
+		p.APS.Badge = apns.NewBadgeNumber(badge)
 
 		p.SetCustomValue("link", "yourapp://precache/20140718")
 

--- a/example/example.go
+++ b/example/example.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"apns"
 	"fmt"
 	"log"
 

--- a/notification.go
+++ b/notification.go
@@ -58,7 +58,7 @@ func (a *Alert) isZero() bool {
 
 type APS struct {
 	Alert            Alert
-	Badge            *int // 0 to clear notifications, nil to leave as is.
+	Badge            BadgeNumber
 	Sound            string
 	ContentAvailable int
 	URLArgs          []string
@@ -75,7 +75,7 @@ func (aps APS) MarshalJSON() ([]byte, error) {
 			data["alert"] = aps.Alert
 		}
 	}
-	if aps.Badge != nil {
+	if aps.Badge.Valid {
 		data["badge"] = aps.Badge
 	}
 	if aps.Sound != "" {


### PR DESCRIPTION
Related to #38 - you told me to do it so I did ;)

Has new `BadgeNumber` struct and methods, along with tests and an updated `MarshalJSON` method for type `APS`.

See #38 for reasoning.