### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -33,7 +33,7 @@ func NewConnWithCert(gw string, cert tls.Certificate) Conn {
 	return Conn{gateway: gw, Conf: &conf}
 }
 
-// NewConnWithFiles creates a new Conn from certificate and key in the specified files
+// NewConn creates a new Conn from certificate and key in the specified files
 func NewConn(gw string, crt string, key string) (Conn, error) {
 	cert, err := tls.X509KeyPair([]byte(crt), []byte(key))
 	if err != nil {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._